### PR TITLE
QoL Mistystep, waits for a left click.

### DIFF
--- a/src/animation-functions/misty-step.js
+++ b/src/animation-functions/misty-step.js
@@ -53,6 +53,7 @@ async function mistyStep(handler) {
 
     let pos;
     canvas.app.stage.addListener('pointerdown', event => {
+        if (event.data.button !== 0) {return}
         pos = event.data.getLocalPosition(canvas.app.stage);
         deleteTemplatesAndMove();
         canvas.app.stage.removeListener('pointerdown');


### PR DESCRIPTION
Now, all mouse buttons can trigger the teleport. If the user is too zoomed in, cant reposition the camera dragging the canvas.
With this QoL improvement, only left click triggers the teleport, the right click can still be used do drag the canvas for a better look.