### PR TITLE
Fix incompatibility with other modules extending the layer config

### DIFF
--- a/src/autoAnimations.js
+++ b/src/autoAnimations.js
@@ -41,22 +41,12 @@ const log = () => { };
 
 function registerLayer() {
     if (game.data.version === "0.7.9" || game.data.version === "0.7.10") {
-        const layers = mergeObject(Canvas.layers, {
+        CONFIG.Canvas.layers = mergeObject(CONFIG.Canvas.layers, {
             autoanimations: AALayer
-        });
-        Object.defineProperty(Canvas, 'layers', {
-            get: function () {
-                return layers
-            }
         });
     } else {
-        const layers = foundry.utils.mergeObject(Canvas.layers, {
+        CONFIG.Canvas.layers = foundry.utils.mergeObject(CONFIG.Canvas.layers, {
             autoanimations: AALayer
-        });
-        Object.defineProperty(Canvas, 'layers', {
-            get: function () {
-                return layers
-            }
         });
     }
 }

--- a/src/autoAnimations.js
+++ b/src/autoAnimations.js
@@ -49,6 +49,18 @@ function registerLayer() {
             autoanimations: AALayer
         });
     }
+
+    // workaround for other modules
+    if (!Object.is(Canvas.layers, CONFIG.Canvas.layers)) {
+        console.error('Possible incomplete layer injection by other module detected! Trying workaround...')
+
+        const layers = Canvas.layers
+        Object.defineProperty(Canvas, 'layers', {
+            get: function () {
+                return foundry.utils.mergeObject(layers, CONFIG.Canvas.layers)
+            }
+        })
+    }
 }
 
 Hooks.on('init', () => {


### PR DESCRIPTION
Follow up to FX Master PR: https://gitlab.com/mesfoliesludiques/foundryvtt-fxmaster/-/merge_requests/41

---

I investigated why the stairways module is incompatible with FX Master and found that FX Master adds its layer in an sub-optimal. (see https://gitlab.com/SWW13/foundryvtt-stairways/-/issues/23#note_601720567 for a bit more details)

This patch should allow other modules to extend the layers config and decrease the chance of future breakage.
~~But it will break while other modules use the define property way of extending layers.~~