### PR TITLE
Partial BetterRolls5e compatibility

### DIFF
--- a/src/autoAnimations.js
+++ b/src/autoAnimations.js
@@ -423,6 +423,10 @@ function setUp5eCore(msg) {
                     if (handler.animType === "t8") { return; }
                     trafficCop(handler);
                     break;
+                case game.modules.get("betterrolls5e")?.active && !handler.hasAttack && handler.hasDamage:
+                    if (handler.animType === "t8") { return; }
+                    trafficCop(handler);
+                    break;
             }
             break;
     }


### PR DESCRIPTION
Hello,

This is an attempt to have partial compatibility with BetterRolls similarly to MRE.

Before the PR, one use case was almost working with BetterRolls & AA:
- BR with "Damage Button In Chat Card" activated
![image](https://user-images.githubusercontent.com/1687854/129192442-6f3436c6-7b49-49d2-82fa-3b1c9d9f5d45.png)
- AA with "Play Attack Animations on Damage Rolls Only" disabled
![image](https://user-images.githubusercontent.com/1687854/129192498-79fbd606-a379-4493-9198-ad86d450a5c9.png)

Only items with damages but no attack roll would fail to display an animation. This PR is here to fix that issue with the stated scenario/settings.

This has no impact on others installations, as it targets only BetterRolls users.

Hope you can merge while waiting for a better implementation of BetterRolls support :)