### PR TITLE
More permissive Auto recognition check

### DIFF
--- a/src/custom-recognition/autoFunctions.js
+++ b/src/custom-recognition/autoFunctions.js
@@ -1,6 +1,6 @@
 export function getAllNames(obj, type) {
     const nameArray = []
-    try {Object.keys(obj[type]).length} 
+    try {Object.keys(obj[type]).length}
     catch (exception) {return nameArray}
     const arrayLength = Object.keys(obj[type]).length
     for (var i = 0; i < arrayLength; i++) {
@@ -11,10 +11,14 @@ export function getAllNames(obj, type) {
 
 export function findObjectByName(data, type, name) {
     const newName = name.toLowerCase()
-    return Object.values(data[type]).filter(section => {
-        //cutting out all spaces
-        return section.name.replace(/\s+/g, '').toLowerCase() === newName ? section : "";
-    })
+    var newObject = Object.values(data[type])
+        .sort((a, b) => b.name.replace(/\s+/g, '').length - a.name.replace(/\s+/g, '').length)
+        .find(section => {
+            //cutting out all spaces
+            return newName.includes(section.name.replace(/\s+/g, '').toLowerCase()) ? section : "";
+        })
+
+    return [newObject]
 }
 
 export function autorecNameCheck(nameArray, name) {
@@ -24,8 +28,9 @@ export function autorecNameCheck(nameArray, name) {
     for (var i = 0; i < arrayLength; i++) {
         //cutting out all spaces
         var currentArrayName = nameArray[i].replace(/\s+/g, '').toLowerCase()
-        if (currentArrayName === newName) {
+        if (newName.includes(currentArrayName)) {
             nameFound = true;
+            break;
         }
     }
     return nameFound;
@@ -54,6 +59,7 @@ export function getAllTheNames(obj) {
             nameArray.push(currentObject[k].name.toLowerCase())
         }
     }
+    nameArray.sort((a, b) => b.length - a.length)
     return nameArray;
 }
 
@@ -62,13 +68,14 @@ export function findObjectByNameFull(data, name) {
     const keyLength = keys.length
     let newObject;
     for (var i = 1; i < keyLength; i++) {
-        var currentObject = data[keys[i]]
-        newObject = Object.values(currentObject).filter(section => {
-            //added .replace()
-            return section.name.replace(/\s+/g, '').toLowerCase() === (name.toLowerCase()) ? section : "";
-        })
+        var newObject = Object.values(data[keys[i]])
+            .sort((a, b) => b.name.replace(/\s+/g, '').length - a.name.replace(/\s+/g, '').length)
+            .find(section => {
+                //added .replace()
+                return name.toLowerCase().includes(section.name.replace(/\s+/g, '').toLowerCase()) ? section : "";
+            })
 
-        if (newObject.length === 1) {return [ newObject, keys[i] ]}
+        if (newObject) { return [[newObject], keys[i]] }
     }
 }
 


### PR DESCRIPTION
Hello,

Related to: https://github.com/otigon/automated-jb2a-animations/issues/216

What this PR does:
- Use `includes` instead of strict comparison.
- Always sort the default animations names from longest to shortest (so we don't match a Sword animation for a Greatsword item, if the Greatsword animation exists as well).


**Example:**
Let's assume the following item name: "Greatsword".
And let's assume the following default animations array/object:
- (0) Sword
- (1) Greatsword
- (2) Long bow

Before comparison, we sort the animations by name (longest to shortest):
- (0) Greatsword
- (1) Long bow
- (2) Sword

Then we find the first suitable animation using includes.
- "Greatsword".includes(`(0) Greatsword`) ➡️ True, and returned
- "Greatsword".includes(`(1) Long bow`) ➡️ False, not returned
- "Greatsword".includes(`(2) Sword`) ➡️ True, but bot returned because `(0) Greatsword` was already returned


**What it allows us to do:**
Have default animations for item names that don't exactly match the default animations names.
- Fire sword -> sword animation
- Ice sword -> sword animation
- Sword of fire -> sword animation
- Greatsword of fire -> Greatsword animation
- Long bow of whatever -> Long bow animation
- My ridiculously long item name with the "sword" name in it -> sword animation

In practice, it means that we don't have to create a custom animation for all variations of the same item.
We can just change the color if needed. And maybe override eveything if wanted.

Another example about "auras". They are quite a few auras in DnD 5e.
With this PR we can create a default "Aura" animation and have it played on all items called "Aura of ....". Then for each aura, we can change the color if we want to.


**Drawbacks:**
As you stated in the issue: `you run the risk of stepping on names of not just other items in the game world, but item names I'm other systems.`

I can not really speak for other system (although I would be surprised that a sword wouldn't require a sword animation in other systems).
For items in the same word. It is entirely possible to have an unintended  animation running for some items.
For example:
- Sword ➡️ Sword animation
- Sword Burst spell ➡️ Sword animation if Sword Burst animation is not created in the default animation object

**Conclusion:**
Although there is a risk of errors in automatic recognition with this PR, I still think the drawbacks don't exceed the advantages of a more permissive recognition.

But I totally understand that you are worried about that. So what I can do, if you consider merging this, is adding a module setting that defaults to strict comparison. The user can activate the permissive comparison if he wants to.
Would that be OK for you?