### PR TITLE
Add support for Better Rolls for SWADE

### DIFF
--- a/src/autoAnimations.js
+++ b/src/autoAnimations.js
@@ -173,6 +173,15 @@ Hooks.on('init', () => {
                 break;
             case "swade":
                 Hooks.on("swadeAction", async (SwadeActor, SwadeItem) => { swadeData(SwadeActor, SwadeItem) });
+                Hooks.on("BRSW-RollItem", async (data, html) => {
+                    var actorId = data.getFlag("betterrolls-swade2", "actor");
+                    var actor = game.actors.get(actorId);
+
+                    var itemId = data.getFlag("betterrolls-swade2", "item_id");
+                    var item = actor.items.get(itemId);
+
+                    swadeData(actor, item) 
+                });
                 break;
             case "wfrp4e":
                 Hooks.on("wfrp4e:rollWeaponTest", async (data, info) => {


### PR DESCRIPTION
Better Rolls for SWADE does not fire the standard swadeAction event but instead its own custom one called BRSW-RollItem. That event contains the data for the actor and item rolled, which can be passed into swadeData.

The other module works by when you first click the item to "roll" it, it instead does not roll anything but creates a chat card
![image](https://user-images.githubusercontent.com/1486841/132988033-076d27b9-5a0e-41e5-ae37-13177a17cc06.png)

Once you click on the Roll button (or shift click the item on the actor), it then does the standard roll to see if it hits and updates the existing chat card, and fires the BRSW-RollItem event
![image](https://user-images.githubusercontent.com/1486841/132988065-3370a889-5574-491c-82d5-006b07829edb.png)

This is where the animation would then be triggered. 
The result of the roll is ignored inline with how Automated Animations works for the base SWADE action and will play regardless of if it hits or not. It is also played before applying damage, but the animation is NOT repeated when rolling damage (as BRSW-RollItem only fires on the base roll)

Better Rolls for SWADE GitHub: https://github.com/javierriveracastro/betteroll-swade