### PR TITLE
initial commit

### DIFF
--- a/src/router/traffic-cop.js
+++ b/src/router/traffic-cop.js
@@ -152,90 +152,96 @@ export async function trafficCop(handler) {
 
             if (isAuto) {
                 const autoObject = AutorecFunctions._findObjectFromArray(autoRecSettings, autoName) // combines Autorec menus and sorts by name length, returns object
-                switch (autoObject.menuSection) {
-                    case 'melee':
-                        if (targets === 0) {
-                            Hooks.callAll("aa.animationEnd", handler.actorToken, "no-target");
-                            if (aaDebug) { aaDebugger("Melee Animation End", "NO TARGETS") }
-                            return;
-                        }
-                        Hooks.callAll("aa.preAnimationStart", handler.actorToken);
-                        if (aaDebug) { aaDebugger("Pre Melee Animation", autoObject) }
-                        itemSound(handler)
-                        meleeAnimation(handler, autoObject);
-                        break;
-                    case 'range':
-                        if (targets === 0) {
-                            Hooks.callAll("aa.animationEnd", handler.actorToken, "no-target");
-                            if (aaDebug) { aaDebugger("Range Animation End", "NO TARGETS") }
-                            return;
-                        }
-                        Hooks.callAll("aa.preAnimationStart", handler.actorToken);
-                        if (aaDebug) { aaDebugger("Pre Range Animation", autoObject) }
-                        itemSound(handler)
-                        rangedAnimations(handler, autoObject);
-                        break;
-                    case 'static':
-                        Hooks.callAll("aa.preAnimationStart", handler.actorToken);
-                        if (aaDebug) { aaDebugger("Pre Static Animation", autoObject) }
-                        itemSound(handler)
-                        staticAnimation(handler, autoObject);
-                        break;
-                    case 'templates':
-                        if (aaDebug) { aaDebugger("Pre Template Animation", autoObject) }
-                        Hooks.once("createMeasuredTemplate", () => {
-                            templateAnimation(handler, autoObject);
-                        })
-                        break;
-                    case 'auras':
-                        if (aaDebug) { aaDebugger("Pre CTA Animation", autoObject) }
-                        itemSound(handler)
-                        auras(handler, autoObject)
-                        break;
-                    case 'preset':
-                        if (aaDebug) { aaDebugger("Pre Preset Animation", autoObject) }
-                        switch (autoObject.animation) {
-                            case 'bardicinspiration':
-                                itemSound(handler)
-                                bardicInspiration(handler, autoObject);
-                                break;
-                            case 'bless':
-                                itemSound(handler)
-                                bless(handler, autoObject);
-                                break;
-                            case 'shieldspell':
-                                itemSound(handler)
-                                shieldSpell(handler, autoObject);
-                                break;
-                            case 'huntersmark':
-                                huntersMark(handler, autoObject);
-                                break;
-                            case 'teleportation':
-                                itemSound(handler)
-                                teleportation(handler, autoObject);
-                                break;
-                            case 'sneakattack':
-                                itemSound(handler);
-                                sneakAttack(handler, autoObject);
-                                break;
-                            case "fireball":
-                                switch (game.system.id) {
-                                    case "dnd5e":
-                                    case "pf2e":
-                                        if (game.modules.get("mars-5e")?.active/* || game.modules.get('midi-qol')?.active*/) {
-                                            fireball(handler, autoObject, true);
-                                        } else {
-                                            Hooks.once("createMeasuredTemplate", () => {
+                for (let i = 1; i <= handler.repeat; i++) {
+                    switch (autoObject.menuSection) {
+                        case 'melee':
+                            if (targets === 0) {
+                                Hooks.callAll("aa.animationEnd", handler.actorToken, "no-target");
+                                if (aaDebug) { aaDebugger("Melee Animation End", "NO TARGETS") }
+                                return;
+                            }
+                            Hooks.callAll("aa.preAnimationStart", handler.actorToken);
+                            if (aaDebug) { aaDebugger("Pre Melee Animation", autoObject) }
+                            itemSound(handler)
+                            meleeAnimation(handler, autoObject);
+                            break;
+                        case 'range':
+                            if (targets === 0) {
+                                Hooks.callAll("aa.animationEnd", handler.actorToken, "no-target");
+                                if (aaDebug) { aaDebugger("Range Animation End", "NO TARGETS") }
+                                return;
+                            }
+                            Hooks.callAll("aa.preAnimationStart", handler.actorToken);
+                            if (aaDebug) { aaDebugger("Pre Range Animation", autoObject) }
+                            itemSound(handler)
+                            rangedAnimations(handler, autoObject);
+                            break;
+                        case 'static':
+                            Hooks.callAll("aa.preAnimationStart", handler.actorToken);
+                            if (aaDebug) { aaDebugger("Pre Static Animation", autoObject) }
+                            itemSound(handler)
+                            staticAnimation(handler, autoObject);
+                            break;
+                        case 'templates':
+                            if (aaDebug) { aaDebugger("Pre Template Animation", autoObject) }
+                            Hooks.once("createMeasuredTemplate", () => {
+                                templateAnimation(handler, autoObject);
+                            })
+                            break;
+                        case 'auras':
+                            if (aaDebug) { aaDebugger("Pre CTA Animation", autoObject) }
+                            itemSound(handler)
+                            auras(handler, autoObject)
+                            break;
+                        case 'preset':
+                            if (aaDebug) { aaDebugger("Pre Preset Animation", autoObject) }
+                            switch (autoObject.animation) {
+                                case 'bardicinspiration':
+                                    itemSound(handler)
+                                    bardicInspiration(handler, autoObject);
+                                    break;
+                                case 'bless':
+                                    itemSound(handler)
+                                    bless(handler, autoObject);
+                                    break;
+                                case 'shieldspell':
+                                    itemSound(handler)
+                                    shieldSpell(handler, autoObject);
+                                    break;
+                                case 'huntersmark':
+                                    huntersMark(handler, autoObject);
+                                    break;
+                                case 'teleportation':
+                                    itemSound(handler)
+                                    teleportation(handler, autoObject);
+                                    break;
+                                case 'sneakattack':
+                                    itemSound(handler);
+                                    sneakAttack(handler, autoObject);
+                                    break;
+                                case "fireball":
+                                    switch (game.system.id) {
+                                        case "dnd5e":
+                                        case "pf2e":
+                                            if (game.modules.get("mars-5e")?.active/* || game.modules.get('midi-qol')?.active*/) {
                                                 fireball(handler, autoObject, true);
-                                            });
-                                        }
-                                        break;
-                                    default:
-                                        fireball(handler, autoObject, true);
-                                }
-                                break;
-                        }
-                        break;
+                                            } else {
+                                                Hooks.once("createMeasuredTemplate", () => {
+                                                    fireball(handler, autoObject, true);
+                                                });
+                                            }
+                                            break;
+                                        default:
+                                            fireball(handler, autoObject, true);
+                                    }
+                                    break;
+                            }
+                            break;
+                    }
+
+                    if (i != handler.repeat) {
+                        await wait(handler.delay)
+                    }
                 }
             } else {
                 itemSound(handler)

--- a/src/system-handlers/flag-handler.js
+++ b/src/system-handlers/flag-handler.js
@@ -69,7 +69,7 @@ export default class flagHandler {
 
         this._options = this._flags.options ?? "";
         this._variant = this._options.variant || "";
-        this._repeat = this._options.repeat || 1;
+        this._repeat = (this._options && this._options.enableCustom && this._options.repeat) || systemData.quantity || 1;
         this._repeatDelay = this._options.delay || 250;
         this._scale = this._options.scale || 1;
         this._opacity = this._options.opacity || 0.75;

--- a/src/system-handlers/getdata-by-system.js
+++ b/src/system-handlers/getdata-by-system.js
@@ -151,8 +151,9 @@ export class AASystemData {
         if (!item || !tokenId) { return; }
         const token = canvas.tokens.get(tokenId) || canvas.tokens.placeables.find(token => token.actor?.items?.get(item?.id) != null);
         const targets = Array.from(input.user.targets);
+        const quantity = Object.keys(input.data.flags.pf1.metadata?.rolls?.attacks ?? {}).length || 1;
 
-        return { item, token, targets };
+        return { item, token, targets, quantity };
     }
 
     static pf2e(input) {


### PR DESCRIPTION
This is just a proof of concept to show it should be pretty easy to cover some simple cases to auto-repeat animations. This will work for anything in PF1 that has separate attack rolls. And then it will force the auto animation to play multiple times. So if a fighter is swinging his sword three times, then it will play the sword auto-animation three times instead of just once.