### PR TITLE
Fixes type errors if no item data provided (5e w/o midi)

### DIFF
--- a/src/autoAnimations.js
+++ b/src/autoAnimations.js
@@ -399,7 +399,7 @@ async function setUp5eCore(msg) {
             rollType = msg.data?.flags?.sw5e?.roll?.type?.toLowerCase() ?? "pass";
             break;
     }
-    if (!handler.item || !handler.actorToken || handler.animKill) {
+    if (!handler?.item || !handler?.actorToken || handler?.animKill) {
         return;
     }
 

--- a/src/system-handlers/flag-handler.js
+++ b/src/system-handlers/flag-handler.js
@@ -7,7 +7,7 @@ export default class flagHandler {
     static async make(msg, isChat, external) {
         const systemID = game.system.id.toLowerCase().replace(/[^a-zA-Z0-9 ]/g, "");
         const data = external ? external : AASystemData[systemID](msg, isChat)
-        if (!data.item) { /*this._log("Retrieval Failed");*/ return; }
+        if (!data?.item) { /*this._log("Retrieval Failed");*/ return; }
         //this._log("Data Retrieved", data)
 
         //console.log(data.item.data.flags.autoanimations)


### PR DESCRIPTION
The problem is handler returns with undefined if item data does not exist so handler.item will raise a typeerror.

fix(autoAnimations): adds optional chaining in `setUp5eCore` when trying to access `handler.item`, `handler.actorToken` and `handler.animKill`
fix(flagHandler): adds optional chaining to `make` when trying to access `data.item`