### PR TITLE
Fix error thrown when chat card doesn't come from an Item

### DIFF
--- a/src/autoAnimations.js
+++ b/src/autoAnimations.js
@@ -467,7 +467,7 @@ async function onCreateChatMessage(msg) {
             handler = await flagHandler.make(msg);
             break;
     }
-    if (!handler.item || !handler.actorToken || handler.animKill) {
+    if (!handler?.item || !handler?.actorToken || handler?.animKill) {
         return;
     }
     trafficCop(handler)

--- a/src/system-handlers/flag-handler.js
+++ b/src/system-handlers/flag-handler.js
@@ -7,7 +7,7 @@ export default class flagHandler {
     static async make(msg, isChat, external) {
         const systemID = game.system.id.toLowerCase().replace(/[^a-zA-Z0-9 ]/g, "");
         const data = external ? external : AASystemData[systemID](msg, isChat)
-        if (!data.item) { /*this._log("Retrieval Failed");*/ return; }
+        if (!data?.item) { /*this._log("Retrieval Failed");*/ return; }
         //this._log("Data Retrieved", data)
 
         //console.log(data.item.data.flags.autoanimations)


### PR DESCRIPTION
In pf1, if I roll something that doesn't come from an item (like a skill) or any chat card made directly from a macro, then I get the following error
```
flag-handler.js:10 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'item')
[Detected 3 packages: autoanimations, lib-wrapper, system:pf1]
    at Function.make (flag-handler.js:10)
    at onCreateChatMessage (autoAnimations.js:464)
    at autoAnimations.js:99
    at Function._call (eval at <anonymous> (listeners.js:91), <anonymous>:4:14)
    at Function.callAll (foundry.js:153)
    at ClientDatabaseBackend.callback (foundry.js:8777)
    at foundry.js:8716
    at Array.map (<anonymous>)
    at ClientDatabaseBackend._handleCreateDocuments (foundry.js:8716)
    at ClientDatabaseBackend._createDocuments (foundry.js:8612)
    at async Function.createDocuments (document.mjs:332)
    at async Function.create (document.mjs:431)
    at async _roll (dice.js:125)
```
Looking through the source, this can happen from any system very easily by just creating a macro that creates a chat card. The problem is in `AASystemData`. Every system handler has this same logic `if (!item || !token) { return; }`. Even more specifically, the problem is `return;` and the code that uses it that I modified in this PR is checking `if (!data.item)` but `data` is undefined because all of those aren't returning anything. So using optional chaining in the one spot it's being consumed safely returns instead of trying to read `item` off of `undefined`.

Run this in the console a script macro to see what it fixes `ChatMessage.create({ content: "Check console for error" })`