### PR TITLE
SWADE: Play animation on correct token

### DIFF
--- a/src/system-handlers/getdata-by-system.js
+++ b/src/system-handlers/getdata-by-system.js
@@ -5,7 +5,7 @@ export class AASystemData {
     * Gather required data:
     * 
     * @param token the Source Token that is using the item
-    * @param item the originating item that is being rolled
+    * @param item the TokenOrActorating item that is being rolled
     * @param targets an Array from target Set, either through Chat Message, Hook or game.user.targets
     * @param hitTargets an Array from a list of HIT targets if supported by system
     * @param reach calculating the cumulative Reach from Race/Weapon/etc. if supported by system
@@ -210,8 +210,9 @@ export class AASystemData {
 
     static swade(input) {
         const item = input.SwadeItem;
-        const actor = input.SwadeActor;
-        const token = canvas.tokens.placeables.find(token => token.actor?.items?.get(item.id) != null) || canvas.tokens.ownedTokens.find(x => x.actor.id === actor.id);
+        const tokenOrActor = input.SwadeTokenOrActor;
+        let token = canvas.tokens.placeables.find(token => token.actor?.items?.get(item.id) != null) || canvas.tokens.ownedTokens.find(x => x.actor.id === tokenOrActor.id);
+        if (tokenOrActor instanceof Token) { token = tokenOrActor; }
         const targets = Array.from(game.user.targets);
         if (!item || !token) { return {}; }
 

--- a/src/system-handlers/getdata-by-system.js
+++ b/src/system-handlers/getdata-by-system.js
@@ -5,7 +5,7 @@ export class AASystemData {
     * Gather required data:
     * 
     * @param token the Source Token that is using the item
-    * @param item the TokenOrActorating item that is being rolled
+    * @param item the originating item that is being rolled
     * @param targets an Array from target Set, either through Chat Message, Hook or game.user.targets
     * @param hitTargets an Array from a list of HIT targets if supported by system
     * @param reach calculating the cumulative Reach from Race/Weapon/etc. if supported by system


### PR DESCRIPTION
This fixes #289 by using the token if there is one provided, or the actor if not. 
For BR2 this was easy, as the hook provides the token so it should always take the correct token to play the animation unless the sheet was opened from the sidebar in which case it uses the first token as earlier.
For SWADE there is no way to do this perfectly as the system does only provide the actor, not the token on the hook. I've tried to create a workaround for it. It will use one of the currently selected tokens (if there are any that match) by looking for actor IDs. So it will work in some cases but not all cases. As I said, this is not failsafe but it's the best I can do without getting the actual token from the systems hook.

Edit: Forgot to credit @javierriveracastro for providing useful help and ideas, couldn't have done it without his help.