### PR TITLE
Add possibility to Play miss animation for AutoAnimation

### DIFF
--- a/src/autoAnimations.js
+++ b/src/autoAnimations.js
@@ -266,14 +266,16 @@ const wait = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
 * sourceToken as the originating token
 * targets as an array from the user
 * item as the item instance being used
+* options to override settings e.g. playOnMiss: true, hitTargets: Array of TokenIDs
 */
 class AutoAnimations {
-    static async playAnimation(sourceToken, targets, item) {
+    static async playAnimation(sourceToken, targets, item, options = {}) {
         if (killAllAnimations) { return; }
         const data = {
             token: sourceToken,
             targets: targets,
             item: item,
+            ...options
         }
         let handler = await flagHandler.make(null, null, data)
         trafficCop(handler);

--- a/src/system-handlers/system-data.js
+++ b/src/system-handlers/system-data.js
@@ -44,7 +44,7 @@ export default class flagHandler {
         this.targetsId = Array.from(this.allTargets.filter(actor => actor.id).map(actor => actor.id));
 
         //midi-qol specific settings
-        this.playOnMiss = data.playOnMiss || midiActive || game.system.id === 'pf2e' ? game.settings.get("autoanimations", "playonmiss") : false;
+        this.playOnMiss = data.playOnMiss || (midiActive || game.system.id === 'pf2e' ? game.settings.get("autoanimations", "playonmiss") : false);
         //this.playOnMiss = true;
         const midiSettings = midiActive ? game.settings.get("midi-qol", "ConfigSettings") : false
         this._gmAD = midiActive ? midiSettings?.gmAutoDamage : "";

--- a/src/system-handlers/system-data.js
+++ b/src/system-handlers/system-data.js
@@ -44,7 +44,7 @@ export default class flagHandler {
         this.targetsId = Array.from(this.allTargets.filter(actor => actor.id).map(actor => actor.id));
 
         //midi-qol specific settings
-        this.playOnMiss = midiActive || game.system.id === 'pf2e' ? game.settings.get("autoanimations", "playonmiss") : false;
+        this.playOnMiss = data.playOnMiss || midiActive || game.system.id === 'pf2e' ? game.settings.get("autoanimations", "playonmiss") : false;
         //this.playOnMiss = true;
         const midiSettings = midiActive ? game.settings.get("midi-qol", "ConfigSettings") : false
         this._gmAD = midiActive ? midiSettings?.gmAutoDamage : "";


### PR DESCRIPTION
Hi, 
I am currently implementing compatiblity to the system The Dark Eye 5th edition.
This already works great. Excellent job on this module (and all dependencies)!

But I would also like to include the miss animation.

For this purpose I propose adding an options object to the parameterlist of AutoAnimation which can override some of the base settings in the SystemData constructor.

E.g. I would like to use it like this:

```
AutoAnimations.playAnimation(attackerToken, targets, item, { hitTargets, playOnMiss: true })
```

This approach has the benefit to add options for critical hits later on easily too, without breaking modules and systems which are already using this.

See also #89 

Thanks for looking into this
Regards

