### PR TITLE
Fix for MRE flow

### DIFF
--- a/src/autoAnimations.js
+++ b/src/autoAnimations.js
@@ -139,7 +139,7 @@ Hooks.once('ready', function () {
                 Hooks.on("createChatMessage", async (msg) => { setupTormenta20(msg) });
                 break;
             case "demonlord":
-                Hooks.on("DL.Action", async (data) => { setupDemonLord(data)});
+                Hooks.on("DL.Action", async (data) => { setupDemonLord(data) });
                 break;
             case "pf2e":
                 Hooks.on("createChatMessage", async (msg) => { pf2eReady(msg) });
@@ -405,8 +405,10 @@ async function setUp5eCore(msg) {
             break;
         case !animationNow:
             switch (true) {
-                case game.modules.get("mre-dnd5e")?.active && game.settings.get("mre-dnd5e", "autoCheck") & !rollType.includes("damage"):
+                case game.modules.get("mre-dnd5e")?.active && game.settings.get("mre-dnd5e", "autoCheck") && !handler.hasAttack && handler.hasDamage && !rollType.includes("damage"):
                     trafficCop(handler);
+                    break;
+                case game.modules.get("mre-dnd5e")?.active && game.settings.get("mre-dnd5e", "autoCheck") && rollType.includes("damage"):
                     break;
                 case rollType.includes("damage") && !handler.hasAttack:
                 case rollType.includes('attack'):


### PR DESCRIPTION
Hello,

This is a fix for MRE.

I was wondering why things didn't quite work with MRE when I saw the typo here: https://github.com/otigon/automated-jb2a-animations/blob/main/src/autoAnimations.js#L408

`& !rollType.includes("damage")` one `&` instead of `&&`

After fixing it, I realized it was not working anyway (would produce and animation on attack roll **and** damage roll).

So I got further to produce this PR.

It only affects the MRE `autoCheck` workflow, and tries to play all animations on attack rather than damage.
It does not impact other modules, core, or other MRE workflows.

Also, I was forced to create a second condition and to break right away because of: https://github.com/otigon/automated-jb2a-animations/blob/main/src/autoAnimations.js#L411

This results in ignoring the two following `case` statements but execute the `inner code` anyway. Something that shoudln't happen when MRE `autoCheck` is checked.
