### PR TITLE
Support base weapon and group matching for PF2e

### DIFF
--- a/src/system-handlers/getdata-by-system.js
+++ b/src/system-handlers/getdata-by-system.js
@@ -189,7 +189,15 @@ export class AASystemData {
         } else {
             hitTargets = targets;
         }
-        return { item, token, targets, hitTargets };
+
+        const extraNames = [];
+        if (item.type === "weapon") {
+            const baseType = game.i18n.localize(CONFIG.PF2E.baseWeaponTypes[item.baseType]);
+            const group = game.i18n.localize(CONFIG.PF2E.weaponGroups[item.group]);
+            extraNames.push(baseType, group);
+        }
+
+        return { item, token, targets, hitTargets, extraNames };
     }
 
     static async forbiddenlands(input) {

--- a/src/system-handlers/system-data.js
+++ b/src/system-handlers/system-data.js
@@ -13,7 +13,7 @@ export default class systemData {
 
         const flags = await flagMigrations.handle(data.item);
 
-        return new systemData(data, flags, msg)
+        return new systemData(data, flags, msg);
     }
 
     constructor(systemData, flagData, msg) {
@@ -75,6 +75,18 @@ export default class systemData {
         this.rinsedName = this.itemName ? AutorecFunctions._rinseName(this.itemName) : "noitem";
         this.isAutorecTemplateItem = AutorecFunctions._autorecNameCheck(AutorecFunctions._getAllNames(this.autorecSettings, 'templates'), this.rinsedName);
         this.autorecObject = AutorecFunctions._findObjectFromArray(this.autorecSettings, this.rinsedName);
+
+        // If there is no match and there are alternative names, then attempt to use those names instead
+        if (!this.autorecObject && data.extraNames?.length) {
+            for (const name of data.extraNames) {
+                const rinsedName = AutorecFunctions._rinseName(name);
+                this.autorecObject = AutorecFunctions._findObjectFromArray(this.autorecSettings, rinsedName);
+                if (this.autorecObject) {
+                    this.rinsedName = rinsedName;
+                    break;
+                }
+            }
+        }
 
         this.isAutorecFireball = false;
         this.isAutorecAura = false;


### PR DESCRIPTION
I was going to add support for the baseItem property in 5e, but I'm noticing that AASystemData.dnd5e has some repetitive code that I'd like to refactor, but I'd rather have your permission first for that.

I'd also like to know if you'd rather handle it another way.

Handles #266 