### PR TITLE
Support Play-On-Damage for PF2E rule-element Strikes

### DIFF
--- a/src/autoAnimations.js
+++ b/src/autoAnimations.js
@@ -875,26 +875,44 @@ async function pf2eReady(msg) {
             break;
         case "melee":
         case "weapon":
-            switch (true) {
-                case playOnDmg:
-                    if (msg.data.flags.pf2e?.damageRoll /*msg.data.flavor?.toLowerCase().includes("damage")*/) {
-                        trafficCop(handler);
-                    }
-                    break;
-                default:
-                    if (msg.data.flags.pf2e?.context?.type.includes("attack")) {
-                        trafficCop(handler);
-                    }
-            }
+            handlePf2eStrike(msg, handler, playOnDmg)
             break;
         case "consumable":
         case "armor":
         case "feat":
         case "action":
         case "effect":
-            trafficCop(handler);
+            if (handler.item.rules.findIndex(x => x.key === "Strike") >= 0) {
+                const wasHandled = handlePf2eStrike(msg, handler, playOnDmg);
+                if (!wasHandled) {
+                    trafficCop(handler);
+                }
+            }
+            else {
+                trafficCop(handler);
+            }
             break;
     }
+}
+
+function handlePf2eStrike(msg, handler, playOnDmg) {
+    const isDamageRoll = !!msg.data.flags.pf2e?.damageRoll; /*msg.data.flavor?.toLowerCase().includes("damage")*/
+    const isAttackRoll = msg.data.flags.pf2e?.context?.type.includes("attack");
+    if (!isAttackRoll && !isDamageRoll) {
+        return false;
+    }
+    switch (true) {
+        case playOnDmg:
+            if (isDamageRoll) {
+                trafficCop(handler);
+            }
+            break;
+        default:
+            if (isAttackRoll) {
+                trafficCop(handler);
+            }
+    }
+    return true;
 }
 
 async function setupA5ESystem(msg) {

--- a/src/system-handlers/system-data.js
+++ b/src/system-handlers/system-data.js
@@ -95,7 +95,12 @@ export default class systemData {
 
         this.rinsedName = this.itemName ? AutorecFunctions._rinseName(this.itemName) : "noitem";
         this.isAutorecTemplateItem = AutorecFunctions._autorecNameCheck(AutorecFunctions._getAllNamesInSection(this.autorecSettings, 'templates'), this.rinsedName);
-        this.autorecObject = this.isActiveEffect || this.pf2eRuleset ? AutorecFunctions._findObjectIn5eAE(this.autorecSettings, this.rinsedName) : AutorecFunctions._findObjectFromArray(this.autorecSettings, this.rinsedName);
+
+        this.autorecObject = this.isActiveEffect || this.pf2eRuleset ? AutorecFunctions._findObjectIn5eAE(this.autorecSettings, this.rinsedName) : null;
+        if (!this.autorecObject) {
+            /* fallback assignment for active effects, default assignment otherwise. */
+            this.autorecObject = AutorecFunctions._findObjectFromArray(this.autorecSettings, this.rinsedName);
+        } 
     
         // If there is no match and there are alternative names, then attempt to use those names instead
         if (!this.autorecObject && data.extraNames?.length) {


### PR DESCRIPTION
Issue #436
PF2E has strikes (attacks) that are created from non-weapon items, such
as feats and effects (e.g. monk stances) using rule-elements. Currently
an animation associated with a feat or effect will play every time a
chat card is played, so it plays on both attack and damage rolls.
Also, autorecognition is broken for these - I think this is due to a
recent change to support active effect lookup better, as it worked about
a month ago.

This commit includes two changes to address these problems:
1. Auto recognition for effects will fall back to the regular lookup if
the effect lookup finds nothing.
2. If a feat, effect, action, consumable, or armor item grants a rule-
element strike, then it will play on either attack or damage rolls
instead of on every message.

This is closely related to #417 and #418 and may need some reshuffling with whatever changes you have planned there.