### PR TITLE
PF2e: Add spell variant support for template animations

### DIFF
--- a/src/system-support/aa-pf2e.js
+++ b/src/system-support/aa-pf2e.js
@@ -50,6 +50,15 @@ async function templateAnimation(input) {
         debug("No Item could be found")
         return;
     }
+    // Spell variants can be identified by the template name
+    const templateName = input.templateData.flags?.pf2e?.origin?.name
+    // If item and template name differ, the variant spell can be created by applying the variants overlay
+    if (templateName && input.item.name !== templateName) {
+        // Search for the variant overlay by name
+        const overlayId = input.item.overlays.find(o => o.name == templateName)?._id
+        if (overlayId) input.item = input.item.loadVariant({ overlayIds: [overlayId] })
+    }
+    
     const handler = await AAHandler.make(input)
     if (!handler) { return;}
     trafficCop(handler)


### PR DESCRIPTION
The PF2e system allows the creation of spell variants. Currently, AA doesn't handle these and just plays the animation for the base spell. 
This PR adds logic that supports the variants for template animations, by passing a modified `item` to the AA handler.

Notes:
- This would be a breaking change for anybody relying on animations using the base items name
- Only handling variants for templates might lead to confusion, since all other animations will still use the "wrong" name