### PR TITLE
Pf1 action patch

### DIFF
--- a/src/system-support/aa-pf1.js
+++ b/src/system-support/aa-pf1.js
@@ -3,21 +3,22 @@ import AAHandler            from "../system-handlers/workflow-data.js";
 import { getRequiredData }  from "./getRequiredData.js";
 
 export function systemHooks() {
-    Hooks.on("createChatMessage", async (msg, html) => {
+    Hooks.on("createChatMessage", async (msg) => {
         if (msg.user.id !== game.user.id) { return };
-        const actionName = message.getFlag("pf1", "metadata")?.action?.name ?? '';
-        const chatName = html.find('.item-name')?.text() ?? '';
+        const actionId = msg.getFlag("pf1", "metadata")?.action;
+        const chatName = $(msg.content).find('.item-name')?.text() ?? '';
         const item = msg.itemSource;
-        if (actionName) {
+        if (item && actionId) {
+            item.actions?.get(actionId)?.name ?? '';
             item.name = `${item.name} ${actionName}`;
         }
-        else if (chatName && chatName.includes(item.name)) {
+        else if (item && chatName && chatName.includes(item.name)) {
             // chat card name should alwyays be either "Item Name" or "Item Name (Action Name)" so this replacement should always be safe
             item.name = chatName;
         }
         const tokenId = msg.speaker?.token;
         const actorId = msg.speaker?.actor;
-        runPF1({item, tokenId, actorId, workflow: msg})
+        runPF1({ item, tokenId, actorId, workflow: msg });
     });
 }
 

--- a/src/system-support/aa-pf1.js
+++ b/src/system-support/aa-pf1.js
@@ -3,9 +3,18 @@ import AAHandler            from "../system-handlers/workflow-data.js";
 import { getRequiredData }  from "./getRequiredData.js";
 
 export function systemHooks() {
-    Hooks.on("createChatMessage", async (msg) => {
+    Hooks.on("createChatMessage", async (msg, html) => {
         if (msg.user.id !== game.user.id) { return };
+        const actionName = message.getFlag("pf1", "metadata")?.action?.name ?? '';
+        const chatName = html.find('.item-name')?.text() ?? '';
         const item = msg.itemSource;
+        if (actionName) {
+            item.name = `${item.name} ${actionName}`;
+        }
+        else if (chatName && chatName.includes(item.name)) {
+            // chat card name should alwyays be either "Item Name" or "Item Name (Action Name)" so this replacement should always be safe
+            item.name = chatName;
+        }
         const tokenId = msg.speaker?.token;
         const actorId = msg.speaker?.actor;
         runPF1({item, tokenId, actorId, workflow: msg})


### PR DESCRIPTION
First block is a better getter that supports grabbing the specific action being used that works in the as-of-now unreleased 0.83.0 pf1.

Second block is fallback that will instead read the name off of the chat card if the event doesn't tell you which action was used (this is how the currently published 0.82.5 pf1 system behaves)-- if the chat card name includes the item's current name, then it replaces the item name with the name from the chat card (this should always be true, I'm just being extra safe by verifying the name matches first).

Essentially both of these options concatenate the Item Name + Action Name so when A-A does the string search for a global match, it can still find something.

E.g. Staff of Fire has three different spells - burning hands, wall of fire, and fireball. Right now for pf1 without this change, A-A only sees the item name "Staff of Fire" which won't match any of those. With this change, A-A will now see `Staff of Fire (Fireball)`, `Staff of Fire (Wall of Fire)`, or `Staff of Fire (Burning Hands)`. So now A-A can match any of those three globally configured animations for the three different actions on this one item.