### PR TITLE
Sentinel on token check to prevent error in OpenD6 Space

### DIFF
--- a/src/system-support/aa-od6s.js
+++ b/src/system-support/aa-od6s.js
@@ -26,7 +26,7 @@ export function systemHooks() {
                 actorId = msg.speaker?.actor;
             }
         } else {
-            tokenId = msg.speaker?.token;
+            tokenId = msg.speaker?.token === null ? "" : msg.speaker?.token;
             actorId = msg.speaker?.actor;
         }
 


### PR DESCRIPTION
Adds a check to prevent an error appearing when someone rolls from an Actor rather than a Token.