### PR TITLE
Prep for upcoming CPRed system update

### DIFF
--- a/src/system-support/aa-cyberpunkred.js
+++ b/src/system-support/aa-cyberpunkred.js
@@ -123,7 +123,11 @@ function getDistance(token, target) {
 }
 
 async function getDV(dvTable, dist) {
-    const pack = game.packs.get("cyberpunk-red-core.dvTables");
+    let pack = game.packs.get("cyberpunk-red-core.dv-tables");
+    if (!pack) {
+        // fallback for older version
+        pack = game.packs.get("cyberpunk-red-core.dvTables");
+    }
     const tableId = pack.index.getName(dvTable)?._id;
     if (!tableId) {
         debug(`Could not get table with name "${dvTable}" from compendium`);


### PR DESCRIPTION
The DV table name will be changed in future versions of the Cyberpunk Red system.
To have a smooth transition when ever that update is released the new compendium name is being used and it has a fall back for the old name in case a user has not updated (or is using the current latest version)