### PR TITLE
SWADE system improvements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -89,6 +89,7 @@
             "hoverInTemplateLayer": "Show on Hover in Template Layer",
             "hoverInTemplate": "Show on any Hover",
             "playAnimations": "When to play Animations",
+            "swadeTraitRolls": "Trait Rolls",
             "attack": "Attack Rolls",
             "damage": "Damage Rolls",
             "disableGrantedAura": "Disable Granted Aura Effect Animations",

--- a/src/gameSettings.js
+++ b/src/gameSettings.js
@@ -786,6 +786,24 @@ class AAGameSettings extends TJSGameSettings {
                }
             });
             break;
+         case "swade":
+            settings.push({
+               namespace,
+               key: "playtrigger",
+               folder: game.system.title || game.system.name,
+               options: {
+                  name: "autoanimations.settings.playAnimations",
+                  scope: scope.world,
+                  type: String,
+                  choices: {
+                     onAttack: "autoanimations.settings.swadeTraitRolls",
+                     onDamage: "autoanimations.settings.damage"
+                  },
+                  default: "onDamage",
+                  config: true
+               }
+            });
+            break;
          /* Considering options for changing 5e options on "How To Play" Animations
       default:
          settings.push({

--- a/src/system-support/aa-swade.js
+++ b/src/system-support/aa-swade.js
@@ -4,7 +4,8 @@ import { getRequiredData }  from "./getRequiredData.js";
 
 export function systemHooks() {
     Hooks.on("swadeAction", async (SwadeTokenOrActor, SwadeItem, SwadeAction) => {
-        if (SwadeAction === "damage" || (SwadeAction === "formula" && !SwadeItem.system.damage)) {
+        const playtrigger = game.settings.get("autoanimations", "playtrigger");
+        if ((SwadeAction === "damage" && playtrigger === "onDamage") || (SwadeAction === "formula" && playtrigger === "onAttack")) {
             const controlledTokens = canvas.tokens.controlled;
             let token;
             if (controlledTokens.length > 0) {

--- a/src/system-support/aa-swade.js
+++ b/src/system-support/aa-swade.js
@@ -11,9 +11,25 @@ export function systemHooks() {
                 token = controlledTokens.find(token => token.document.actorId === SwadeTokenOrActor.id);
             }
             if (token) { SwadeTokenOrActor = token; }
-            runSwade(SwadeTokenOrActor, SwadeTokenOrActor, SwadeItem)
+            runSwade(SwadeTokenOrActor, SwadeTokenOrActor, SwadeItem);
         }
     });
+    Hooks.on("swadeConsumeItem", async (SwadeItem, charges, usage) => {
+        const controlledTokens = canvas.tokens.controlled;
+        let token;
+        let SwadeTokenOrActor = SwadeItem.parent
+        if (controlledTokens.length > 0) {
+          token = controlledTokens.find(token => token.document.actorId === SwadeTokenOrActor.id);
+        }
+        if (token) {
+          SwadeTokenOrActor = token;
+        }
+        runSwade(SwadeTokenOrActor, SwadeTokenOrActor, SwadeItem);
+    });
+    Hooks.on("createMeasuredTemplate", async (template, data, userId) => {
+        if (userId !== game.user.id || !template.flags?.swade?.origin) return;
+        templateAnimation(await getRequiredData({itemUuid: template.flags?.swade?.origin, templateData: template, workflow: template, isTemplate: true}))
+    })
     async function get_brsw_data (data) {
         //var tokenId = data.getFlag("betterrolls-swade2", "token");
         return {token: data.token, actor: data.actor, item: data.item}

--- a/src/system-support/aa-swade.js
+++ b/src/system-support/aa-swade.js
@@ -1,9 +1,11 @@
-import { trafficCop }       from "../router/traffic-cop.js"
-import AAHandler            from "../system-handlers/workflow-data.js";
-import { getRequiredData }  from "./getRequiredData.js";
+import { debug } from "../constants/constants.js";
+import { trafficCop } from "../router/traffic-cop.js";
+import AAHandler from "../system-handlers/workflow-data.js";
+import { getRequiredData } from "./getRequiredData.js";
 
 export function systemHooks() {
-    Hooks.on("swadeAction", async (SwadeTokenOrActor, SwadeItem, SwadeAction) => {
+    Hooks.on("swadeAction", async (SwadeTokenOrActor, SwadeItem, SwadeAction, SwadeRoll, userId) => {
+        if (!SwadeRoll) { return; }
         const playtrigger = game.settings.get("autoanimations", "playtrigger");
         if ((SwadeAction === "damage" && playtrigger === "onDamage") || (SwadeAction === "formula" && playtrigger === "onAttack")) {
             const controlledTokens = canvas.tokens.controlled;
@@ -69,6 +71,15 @@ export function systemHooks() {
     })
 }
 
+async function templateAnimation(input) {
+    debug("Template placed, checking for animations")
+    if (!input.item) {
+        debug("No Item could be found")
+        return;
+    }
+    const handler = await AAHandler.make(input)
+    trafficCop(handler)
+}
 // TO-DO, CHECK SWADE
 async function runSwade(token, actor, item) {
     let data = await getRequiredData({token, actor, item })


### PR DESCRIPTION
This adds a few improvements to the SWADE game system:
- Adds a playTrigger setting to make allow playing animations on Trait Rolls instead of just Damage Rolls.
- New hook: swadeConsumeItem will execute when using a consumable item, such as a health potion.
- New hook: createMeasuredTemplate will execute in the same way it does for dnd5e



https://github.com/otigon/automated-jb2a-animations/assets/5288872/5523c6ec-7a71-4f7d-b6a8-9962ca8a08e7

