### PR TITLE
PF2e: Full spell variant support

### DIFF
--- a/src/system-handlers/findAnimation.js
+++ b/src/system-handlers/findAnimation.js
@@ -73,6 +73,11 @@ export async function handleItem(data) {
                     }
                 }
             }
+            if (!autorecObject && data.isVariant && !data.isTemplate) {
+                let originalItemName = data.originalItem?.name
+                let originalRinsedName = originalItemName ? AAAutorecFunctions.rinseName(originalItemName) : "noitem"
+                autorecObject = AAAutorecFunctions.allMenuSearch(menus, originalRinsedName, originalItemName);
+            }
         }    
     }
     
@@ -83,7 +88,7 @@ export async function handleItem(data) {
         }
     } else if ( data.isVariant && !autorecObject && data.isTemplate && !autorecDisabled) {
         // For use with Variant spell casting, based off PF2e. If the variant name is not found in the Global menu, it looks for one matching the original name
-        let newItemName = input.originalItem?.name;
+        let newItemName = data.originalItem?.name;
         let newRinsedName = newItemName ? AAAutorecFunctions.rinseName(newItemName) : "noitem";
         autorecObject = AAAutorecFunctions.allMenuSearch(menus, newRinsedName, newItemName);
     }


### PR DESCRIPTION
pf2e v5 fixed spell variant info missing from attack rolls and saves. 
Changes tested on both v11 and v10.

Minor question: The variant handling could be merged into the extraNames property, like the pf2e and witcher trpg handlers are already using. Would you prefer that over the duplicated logic?