### PR TITLE
Prevent error with Cypher System chat cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Current System Compatibility:
 - [ShadowRun5e](https://foundryvtt.com/packages/shadowrun5e/)
 - Level Up A5E
 - [Dungeonslayers 4](https://foundryvtt.com/packages/ds4)
+- [Cypher System](https://foundryvtt.com/packages/cyphersystem)
 
 Systems in Process for Compatibility:   
 - Please log a GitHub request for other systems  

--- a/src/system-support/aa-cyphersystem.js
+++ b/src/system-support/aa-cyphersystem.js
@@ -34,47 +34,49 @@ async function runCypherSystem(input) {
         // First crits etc
         
         const flagdata = input.workflow?.flags?.data;
-        var diceRoll = flagdata?.roll?.total || 10;
+        const diceRoll = flagdata?.roll?.total;
         
-        if (game.settings.get("autoanimations", "EnableCritical") && diceRoll >= 19)
-        {
-            new Sequence()
-                .effect()
-                .file(game.settings.get("autoanimations", "CriticalAnimation"))
-                .atLocation(input.token)
-                .play()
-        }
-        else if (game.settings.get("autoanimations", "EnableFumble") && diceRoll <= flagdata.gmiRange)
-        {
-            new Sequence()
-                .effect()
-                .file(game.settings.get("autoanimations", "FumbleAnimation"))
-                .atLocation(input.token)
-                .play()
-        }
-        else if (flagdata.pool == "Might" && game.settings.get("autoanimations", "EnableOnMightRoll"))
-        {
-            new Sequence()
-                .effect()
-                .file(game.settings.get("autoanimations", "MightRollAnimation"))
-                .atLocation(input.token)
-                .play()
-        }
-        else if (flagdata.pool == "Speed" && game.settings.get("autoanimations", "EnableOnSpeedRoll"))
-        {
-            new Sequence()
-                .effect()
-                .file(game.settings.get("autoanimations", "SpeedRollAnimation"))
-                .atLocation(input.token)
-                .play()
-        }
-        else if (flagdata.pool == "Intellect" && game.settings.get("autoanimations", "EnableOnIntellecRoll"))
-        {
-            new Sequence()
-                .effect()
-                .file(game.settings.get("autoanimations", "IntellectRollAnimation"))
-                .atLocation(input.token)
-                .play()
+        if (diceRoll) {
+            if (game.settings.get("autoanimations", "EnableCritical") && diceRoll >= 19)
+            {
+                new Sequence()
+                    .effect()
+                    .file(game.settings.get("autoanimations", "CriticalAnimation"))
+                    .atLocation(input.token)
+                    .play()
+            }
+            else if (game.settings.get("autoanimations", "EnableFumble") && diceRoll <= flagdata.gmiRange)
+            {
+                new Sequence()
+                    .effect()
+                    .file(game.settings.get("autoanimations", "FumbleAnimation"))
+                    .atLocation(input.token)
+                    .play()
+            }
+            else if (flagdata.pool == "Might" && game.settings.get("autoanimations", "EnableOnMightRoll"))
+            {
+                new Sequence()
+                    .effect()
+                    .file(game.settings.get("autoanimations", "MightRollAnimation"))
+                    .atLocation(input.token)
+                    .play()
+            }
+            else if (flagdata.pool == "Speed" && game.settings.get("autoanimations", "EnableOnSpeedRoll"))
+            {
+                new Sequence()
+                    .effect()
+                    .file(game.settings.get("autoanimations", "SpeedRollAnimation"))
+                    .atLocation(input.token)
+                    .play()
+            }
+            else if (flagdata.pool == "Intellect" && game.settings.get("autoanimations", "EnableOnIntellecRoll"))
+            {
+                new Sequence()
+                    .effect()
+                    .file(game.settings.get("autoanimations", "IntellectRollAnimation"))
+                    .atLocation(input.token)
+                    .play()
+            }
         }
 
         // Always check for an Item animation, as well as the pool/critical/GMI animation


### PR DESCRIPTION
For Cypher System:

- This small update prevents an error being reported in the console when a chat card doesn't reference a dice roll.
- Adds Cypher System to the supported systems list in `readme.MD`
