### PR TITLE
Updated PF1 to include more data and added name override

### DIFF
--- a/src/system-handlers/findAnimation.js
+++ b/src/system-handlers/findAnimation.js
@@ -61,26 +61,25 @@ export async function handleItem(data) {
         if (itemFlags.isCustomized) {
             return itemFlags;
         } else if (!autorecDisabled) {
-            autorecObject = AAAutorecFunctions.allMenuSearch(menus, rinsedItemName, itemName);
-            if (!autorecObject && data.extraNames?.length && !data.activeEffect) {
-                for (const name of data.extraNames) {
-                    if (!name) { continue }
-                    const rinsedName = AAAutorecFunctions.rinseName(name);
-                    autorecObject = AAAutorecFunctions.allMenuSearch(menus, rinsedName, itemName);
-                    if (autorecObject) {
-                        data.rinsedName = rinsedName;
-                        break;
-                    }
+            const prioritizedNames = [...(data.overrideNames || []), itemName, ...(data.extraNames || [])];
+            prioritizedNames.find((name) => {
+                const rinsedName = AAAutorecFunctions.rinseName(name);
+                const found = AAAutorecFunctions.allMenuSearch(menus, rinsedName, name);
+                if (found) {
+                    autorecObject = found;
+                    data.rinsedName = rinsedName;
                 }
-            }
+                return !!found;
+            });
+
             if (!autorecObject && data.isVariant && !data.isTemplate) {
                 let originalItemName = data.originalItem?.name
                 let originalRinsedName = originalItemName ? AAAutorecFunctions.rinseName(originalItemName) : "noitem"
                 autorecObject = AAAutorecFunctions.allMenuSearch(menus, originalRinsedName, originalItemName);
             }
-        }    
+        }
     }
-    
+
     if (autorecObject && data.isTemplate && !autorecDisabled) {
         let data = autorecObject;
         if (data.menu === "range" || data.menu === "melee" || data.menu === "ontoken") {

--- a/src/system-support/aa-pf1.js
+++ b/src/system-support/aa-pf1.js
@@ -1,33 +1,66 @@
-import { trafficCop }       from "../router/traffic-cop.js"
-import AAHandler            from "../system-handlers/workflow-data.js";
-import { getRequiredData }  from "./getRequiredData.js";
+import { trafficCop } from "../router/traffic-cop.js"
+import AAHandler from "../system-handlers/workflow-data.js";
+import { getRequiredData } from "./getRequiredData.js";
 
 export function systemHooks() {
     Hooks.on("createChatMessage", async (msg) => {
-        if (msg.user.id !== game.user.id) { return };
-        const actionId = msg.getFlag("pf1", "metadata")?.action;
-        const chatName = $(msg.content).find('.item-name')?.text() ?? '';
-        const itemFromChat = msg.itemSource;
-        if (!itemFromChat) { return; };
-        const item = itemFromChat.toObject();
-        //const item = foundry.utils.duplicate(itemFromChat);
+        if (msg.user.id !== game.user.id) {
+            return
+        };
+
+        // is this good or necessary?
+        if (msg.speaker?.scene !== game.scenes.current?.id) {
+            return;
+        }
+
+        const data = {
+            actor: msg.itemSource?.actor,
+            actorId: msg.speaker?.actor,
+            ammoId: msg.flags.pf1.metadata.rolls?.attacks?.map((attack) => attack.ammo?.id),
+            itemId: msg.flags.pf1.metadata.item,
+            item: msg.itemSource,
+            targetIds: msg.flags.pf1.metadata.targets,
+            templateDataId: msg.flags.pf1.metadata.template,
+            tokenId: msg.speaker?.token,
+            workflow: msg,
+        };
+        let compiledData = await getRequiredData(data);
+
+        // todo add ammo - looks like it might need to parsed out of the html content
+        const item = compiledData.item;
+        if (!item) {
+            return;
+        }
+
+        // set up override for "action name"
+        //  This is for cases like "Staff of Fire" that can cast "Fireball", "Burning Hands", "Wall of Fire"
+        //  We want to use those specific action names because we don't want to cast "Fireball" but see a "Staff" thwack everyone 
+        //     ...as funny as that would be 😛
+        const actionId = msg.flags.pf1.metadata.action;
         if (item && actionId) {
             const actionName = item.actions?.get(actionId)?.name ?? '';
-            item.name = `${item.name} ${actionName}`;
+            if (actionName) {
+                compiledData.overrideNames.push(actionName);
+            }
         }
-        else if (item && chatName && chatName.includes(item.name)) {
-            // chat card name should alwyays be either "Item Name" or "Item Name (Action Name)" so this replacement should always be safe
-            item.name = chatName;
+
+        if (item instanceof pf1.documents.item.ItemWeaponPF || item instanceof pf1.documents.item.ItemAttackPF) {
+            // add weapon base types (i.e. if item "Fancy Magic Stick" is a base type "Quarterstaff" then we can fall back to quarterstaff)
+            compiledData.extraNames.push(...(item.system.baseTypes || []));
+
+            // fall back to weapon groups after base weapon name 
+            const groupsOnItem = [
+                ...(item.system.weaponGroups?.value || []).map((key) => pf1.config.weaponGroups[key]),
+                ...(item.system.weaponGroups?.custom || '').split(';')
+            ].filter((x) => !!x);
+            compiledData.extraNames.push(...groupsOnItem);
         }
-        const tokenId = msg.speaker?.token;
-        const actorId = msg.speaker?.actor;
-        runPF1({ item, tokenId, actorId, workflow: msg });
+
+        runPF1(compiledData);
     });
 }
 
-async function runPF1(input) {
-    const requiredData = await getRequiredData(input)
-    if (!requiredData.item) { return; }
+async function runPF1(requiredData) {
     const handler = await AAHandler.make(requiredData)
     trafficCop(handler);
 }

--- a/src/system-support/aa-pf1.js
+++ b/src/system-support/aa-pf1.js
@@ -16,7 +16,7 @@ export function systemHooks() {
         const data = {
             actor: msg.itemSource?.actor,
             actorId: msg.speaker?.actor,
-            ammoId: msg.flags.pf1.metadata.rolls?.attacks?.map((attack) => attack.ammo?.id),
+            ammoId: msg.flags.pf1.metadata.rolls?.attacks?.map((attack) => attack.ammo?.id)[0],
             itemId: msg.flags.pf1.metadata.item,
             item: msg.itemSource,
             targetIds: msg.flags.pf1.metadata.targets,

--- a/src/system-support/getRequiredData.js
+++ b/src/system-support/getRequiredData.js
@@ -1,8 +1,9 @@
 import { aaDeletedItems } from "../deletedItems";
 
 export async function getRequiredData(data) {
-    //let {item, itemId, itemUuid, itemName, token, tokenId, tokenUuid, targets, actorId, actor} = data;
+    //let {item, itemId, itemUuid, itemName, token, tokenId, tokenUuid, targets, targetIds, actorId, actor, templateId, ammoId} = data;
 
+    // set up token and item ... and try to set up token some more if it still doesn't work
     if (!data.token) {
         data.token = getToken(data);
     }
@@ -13,9 +14,9 @@ export async function getRequiredData(data) {
     if (!data.item && data.itemUuid) {
         if (game.modules.get("magicitems")?.active) {
             const splitUuid = data.itemUuid.split('.');
-            const id = splitUuid[splitUuid.length - 1];    
+            const id = splitUuid[splitUuid.length - 1];
             data.item = game.packs.get("dnd5e.spells")?.index?.get(id)
-        }  
+        }
     }
     if (!data.token && data.item) {
         // Last ditch effort to find a token
@@ -24,11 +25,33 @@ export async function getRequiredData(data) {
     if (!data.token) {
         data.token = _token;
     }
+
+    // set up targets
+    if (!data.targets && data.targetIds?.length) {
+        data.targets = data.targetIds.map((id) => canvas.scene.tokens.get(id));
+    }
     if (!data.targets) {
         data.targets = Array.from(game.user.targets)
     }
 
-    return {...data}
+    // set up ammo
+    if (data.ammoId && !data.ammoItem && data.token) {
+        data.ammoItem = getItemFromToken(data.token, data.ammoId);
+    }
+
+    // set up template
+    if (!data.templateData && data.templateDataId) {
+        data.templateData = canvas.scene.templates.get(data.templateDataId);
+    }
+    if (data.templateData) {
+        data.isTemplate = true;
+    }
+
+    // set up empty name arrays so each system handler doesn't have to define them on their own
+    data.extraNames ||= [];
+    data.overrideNames ||= [];
+
+    return { ...data }
     //return {item: data.item, token: data.token, targets: data.targets}
 }
 


### PR DESCRIPTION
- Updated `getRequiredData` to look up more docs based on ids passed in
- Added `overrideNames` to `data` and updated `findAnimation` so systems can pass in names to look up _before_ the item name is checked. Basically exactly like `extraNames` but these are checked first instead of last.
- Updated PF1 integration
  - Action names (pf1 has "actions" where one item can have multiple actions) are set up using new `overrideNames` property so they're used first. This allows something like "Staff of Fire" to have a "Fireball" or "Burning Hands" that are both independently recognized correctly without Staff of Fire triggering a melee staff animation
  - Included ammo ids that should be coming out at some point in a future update
  - Added template data so that's available to the workflow
  - Added explicit target ids from the chat message in case they're different from those selected in the UI (a mod could update those in the chat data before it's finalized, for example -- still falls back to UI selected targets in case the data isn't in the chat message)
  - Added weapon group extra names like PF2 does so someone can set up generic animations based on the group