### PR TITLE
Return token instead of token doc for target lookup

### DIFF
--- a/src/system-support/getRequiredData.js
+++ b/src/system-support/getRequiredData.js
@@ -28,7 +28,7 @@ export async function getRequiredData(data) {
 
     // set up targets
     if (!data.targets && data.targetIds?.length) {
-        data.targets = data.targetIds.map((id) => canvas.scene.tokens.get(id));
+        data.targets = data.targetIds.map((id) => canvas.scene.tokens.get(id)?.object).filter(x => !!x);
     }
     if (!data.targets) {
         data.targets = Array.from(game.user.targets)


### PR DESCRIPTION
Target lookup I added for PF1 was returning the token documents instead of the token itself which was causing issues for setting up secondary animations.