### PR TITLE
Fixed active effect copying item animation for DnD

### DIFF
--- a/src/active-effects/handleActiveEffectHooks.js
+++ b/src/active-effects/handleActiveEffectHooks.js
@@ -77,6 +77,7 @@ export function registerActiveEffectHooks() {
                 if (game.user.id !== userId) { return; }
                 toggleActiveEffects(data, toggle)
             });
+            break;
         case "pf1":
             Hooks.on("createActiveEffect", async (effect, data, userId) => {
                 if (game.settings.get("autoanimations", "disableAEAnimations")) {


### PR DESCRIPTION
A break; was missing in the previous update.