### PR TITLE
Lancer integration improvements

### DIFF
--- a/src/system-support/aa-lancer.js
+++ b/src/system-support/aa-lancer.js
@@ -1,4 +1,5 @@
 // Support added by Wibble199
+// With thanks to @dodgepong (Lancer Weapon FX) for help
 
 import AAHandler from "../system-handlers/workflow-data";
 import { getRequiredData } from "./getRequiredData";
@@ -29,26 +30,77 @@ export function systemHooks() {
 }
 
 function getHandlerInputData(msg) {
-	const html = $(msg.content);
+	const parser = new DOMParser();
+	const messageDocument = parser.parseFromString(msg.content, "text/html");
+
+	// As far as I can tell AA only seems to use the item.name property, so in some cases here I just pass a fake object
+	// if there is no actual item (such as for core systems, or things such as "Overheat"). It's hacky but seems to work
+
+
+	// Try to grab the data from the roll data that is encoded in the template.
+	// Massive shout out to @dodgepong for this!
+	const encodedRollData = messageDocument.querySelector("[data-macro]")?.dataset["macro"];
+	if (encodedRollData) {
+		const rollData = JSON.parse(decodeURIComponent(atob(encodedRollData)));
+
+		switch (rollData.fn) {
+			case "prepareEncodedAttackMacro":
+			case "prepareActivationMacro":
+				// args[1] is the ID of the item that triggered the macro
+				// If the user clicked the generic "Melee/Ranged" button, args[1] will be null. In this case we'll not
+				// do any animation.
+				const itemId = rollData.args[1];
+				if (!!itemId) return { itemId };
+				break;
+
+			case "prepareTechMacro":
+				// args[1] is the ID of the item that triggered the macro
+				// If the user clicked the generic "Tech" button, args[1] will be null. In this case, return a fake obj
+				// with the name "Tech Attack".
+				const techId = rollData.args[1];
+				if (!!techId) return { itemId: techId };
+				return { item: { name: "Tech Attack" } };
+			
+			case "prepareOverheatMacro":
+				return { item: { name: "Overheat" } };
+
+			case "prepareStructureMacro":
+				return { item: { name: "Structure Damage" } };
+		}
+	}
 
 	// Item IDs not provided in message data, so try and pull from the HTML
 	// For items, there is a `data-id` attribute in the root HTML content for the chat message
-	const itemId = html.data('id');
+	const itemId = messageDocument.body.children[0]?.dataset["id"];
 	if (!!itemId) {
 		return { itemId };
 	}
 
-	// Core systems are not items, but as far as I can tell AA only seems to use the item.name property, so we can just
-	// pass a fake object if the template's title matches the mech's core system.
-	// This is a bit hacky but seems to work :)
-	const headerText = html.find('.lancer-header').text();
+	// Some other systems (such as cores or NPC features), do not have an item ID or roll data, so see if we can grab
+	// the name from the chat card header and sent that as a fake item.
+	const headerText = messageDocument.querySelector('.lancer-header')?.textContent;
 	if (typeof headerText === 'string' && !!headerText.length) {
 		const headerTextRinised = rinseHeader(headerText);
-		const actor = msg.speaker?.actor && game.actors.get(msg.speaker.actor);
-		const frame = actor?.items.find(i => i.type === "frame");
+		// Used to check here whether this was the core system, but there are other items too that don't have an ID nor
+		// roll data. There's probably too many places to check, so going to make the assumption that if the chat card
+		// has a header, that header text can be used as the item name.
 
-		if (frame?.system?.core_system?.active_name?.toLowerCase() === headerTextRinised.toLowerCase()) {
-			return { item: { name: headerTextRinised } };
+		// Stabilize headers are "// <MECH NAME> HAS STABILIZED//", so special case for that.
+		if (headerTextRinised.toLowerCase().endsWith("has stabilized")) {
+			return { item: { name: "Stabilize" } };
+		}
+
+		return { item: { name: headerTextRinised } };
+	}
+
+	// Overcharging does not use the header like many other features, have to check a different element instead.
+	const statHeaderText = messageDocument.querySelector(".lancer-stat-header")?.textContent;
+	if (typeof statHeaderText === 'string' && !!statHeaderText.length) {
+		const statHeaderTextRinsed = rinseHeader(statHeaderText);
+
+		// Overcharging is in the form "// <MECH NAME> is OVERCHARGING //"
+		if (statHeaderTextRinsed.toLowerCase().endsWith("is overcharging")) {
+			return { item: { name: "Overcharge" } };
 		}
 	}
 

--- a/src/system-support/aa-lancer.js
+++ b/src/system-support/aa-lancer.js
@@ -15,6 +15,17 @@ export function systemHooks() {
 			return;
 		}
 
+		// getRequiredData attempts to resolve the token. It does so by first looking to see if an item has been passed
+		// in the parameter object. If there is an item or item ID, it tries to get the owner of that item. This works
+		// fine for weapons. However, in cases where the Lancer system does not provide an item/I'm using a fake item
+		// (e.g. stabilize), then because getRequiredData can't access the item's owner, it defaults to using null as
+		// the source token, even if I've provided a tokenId. So, if the itemData I've got from the chat message does
+		// not contain either an itemId or an item object with an ID, then resolve the token here, and pass that in to
+		// get around this issue.
+		if (!itemData.itemId && !itemData.item?.id) {
+			itemData.token = game.canvas.tokens.get(msg.speaker?.token);
+		}
+
 		const compiledData = await getRequiredData({
 			...itemData,
 			actorId: msg.speaker?.actor,


### PR DESCRIPTION
Couple tweaks and improvements to the Lancer system integration:
- Fix NPC traits and features not triggering an animation.
- Fix source token being incorrect for some of the items
- Use the encoded roll data (thanks to dodgepong for informing me about this) to also detect overheating, and structure damages.
- Add stabilize and overcharge.