### PR TITLE
Add xray as an option to AA template menu

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -485,7 +485,8 @@
             "illusion": "Illusion",
             "necromancy": "Necromancy",
             "transmutation": "Transmutation",
-            "arcana": "Arcana"
+            "arcana": "Arcana",
+            "xray": "XRay"
         },
         "menuTypes": {
             "creature": "Creature Attack",

--- a/src/aa-classes/DataSanitizer.js
+++ b/src/aa-classes/DataSanitizer.js
@@ -236,6 +236,7 @@ export class DataSanitizer {
                     tintColor: data.tintColor || "#FFFFFF",
                     scaleX: data.scaleX || 1,
                     scaleY: data.scaleY || 1,
+                    xray: data.xray ?? false,
                     zIndex: data.zIndex || 1,
                 };
             case "aura":

--- a/src/animation-functions/standard-sequences/templateAnimation.js
+++ b/src/animation-functions/standard-sequences/templateAnimation.js
@@ -186,6 +186,7 @@ export async function templatefx(handler, animationData, templateDocument) {
         seq.playbackRate(data.options.playbackRate)
         seq.name(handler.rinsedName)
         seq.aboveLighting(data.options.aboveTemplate)
+        seq.xray(data.options.xray)
         if (data.options.tint) {
             seq.tint(data.options.tintColor)
             seq.filter("ColorMatrix", {contrast: data.options.contrast, saturate: data.options.saturation})

--- a/src/formApps/Menus/Components/options/TemplateOptions.svelte
+++ b/src/formApps/Menus/Components/options/TemplateOptions.svelte
@@ -180,7 +180,20 @@
                 </td>
             </tr>
             <tr>
-                <td></td>
+                <td>
+                    <!--Ignore vision-based masking-->
+                    <div>
+                        <label for="xray {animation._data.id}"
+                            >{localize("autoanimations.variants.xray")}
+                        </label>
+                        <input
+                            type="checkbox"
+                            id="xray {animation._data.id}"
+                            bind:checked={$animation.primary.options
+                                .xray}
+                        />
+                    </div>
+                </td>
                 <td>
                     <WaitDelay {animation}/>
                 </td>

--- a/src/formApps/Menus/Components/options/optionsInfo/sections/templatefx.svelte
+++ b/src/formApps/Menus/Components/options/optionsInfo/sections/templatefx.svelte
@@ -109,6 +109,12 @@
     </tr>
     <tr>
         <td class="aa-table">
+            <strong>{localize("autoanimations.variants.xray")}</strong>
+        </td>
+        <td> This will cause the effect to ignore vision-based masking </td>
+    </tr>
+    <tr>
+        <td class="aa-table">
             <strong>{localize("autoanimations.menus.z-index")}</strong>
         </td>
         <td> Index of the animation when they are played at the same elevation </td>


### PR DESCRIPTION
This is really useful for templates that use Limits to block vision

![image](https://github.com/otigon/automated-jb2a-animations/assets/25332081/0974cea6-7486-4947-92b0-56eafe00bf0c)
![image](https://github.com/otigon/automated-jb2a-animations/assets/25332081/fcdb9c7d-85ac-4ef8-a12f-ad61c75061cf)
