### PR TITLE
Add compatibility with the dnd5e module WIRE

### DIFF
--- a/src/system-support/aa-dnd5e.js
+++ b/src/system-support/aa-dnd5e.js
@@ -22,6 +22,8 @@ export function systemHooks() {
             useItem(getWorkflowData(workflow))
         });
     
+    } else if (game.modules.get("wire")?.active) {
+        // WIRE handles triggering AA
     } else {
         Hooks.on("dnd5e.preRollAttack", async (item, options) => {
             let spellLevel = options.spellLevel ?? void 0;


### PR DESCRIPTION
WIRE reworks the dnd5e item roll process, and there are some incompatibilities between WIRE, Automated Animations and some other modules like Build-A-Bonus. This PR adds compatibility by disabling AA's attack hooks and letting WIRE do the triggering.