### PR TITLE
Midi-QoL attacking token fix

### DIFF
--- a/src/system-support/aa-dnd5e.js
+++ b/src/system-support/aa-dnd5e.js
@@ -120,7 +120,7 @@ function checkReach(data) {
 function getWorkflowData(data) {
     return {
         item: data.item,
-        token: data.token,
+        token: data.rangeDetails?.attackingToken ?? data.token,
         targets: Array.from(data.targets),
         hitTargets: Array.from(data.hitTargets),
         spellLevel: data.castData?.castLevel ?? void 0,


### PR DESCRIPTION
This allows the animations from this module to come from the proper attacking token when making use of certain Midi-Qol flags.