### PR TITLE
OpenD6 Space: Add checks for explosive templates to avoid double-triggering animations

### DIFF
--- a/src/system-support/aa-od6s.js
+++ b/src/system-support/aa-od6s.js
@@ -9,8 +9,11 @@ import { getRequiredData }  from "./getRequiredData.js";
 
 export function systemHooks() {
     Hooks.on("createChatMessage", async (msg) => {
-        if (msg.user.id !== game.user.id || !AnimationState.enabled) { return };
-        if (msg.getFlag('od6s', 'type') === 'damage') { return };
+        if (msg.user.id !== game.user.id || !AnimationState.enabled) { return }
+        if (msg.getFlag('od6s', 'type') === 'damage') { return }
+        if (msg.getFlag('od6s', 'isExplosive')) {
+            if(!msg.getFlag('od6s','triggered')) { return }
+        }
 
         // Was this from an actor-controlled vehicle?
         let tokenId = '';


### PR DESCRIPTION
Adds flag checks to messages to avoid double-triggering animations on explosives in the OpenD6 Space system.