### PR TITLE
Tile creation patch

### DIFF
--- a/src/animation-functions/standard-sequences/templateAnimation.js
+++ b/src/animation-functions/standard-sequences/templateAnimation.js
@@ -221,6 +221,7 @@ export async function templatefx(handler, animationData, templateDocument) {
             width: tileWidth,
             height: tileHeight,
             img: data.path.filePath,
+            texture: { src: data.path.filePath }, // v12 uses this instead of img:
             overhead: isOverhead, // false sets Tile in canvas.background. true sets Tile to canvas.foreground
             occlusion: {
                 alpha: `${data.options.occlusionAlpha}`,


### PR DESCRIPTION
Currently tiles created e.g. through the placement of tiles have an empty attribute for texture.src. This is due to v12 changes the field img was deprecated.

The change should be ok for both v11 and v12