### PR TITLE
dnd5e v4 compatibility

### DIFF
--- a/src/system-support/aa-dnd5e.js
+++ b/src/system-support/aa-dnd5e.js
@@ -78,7 +78,7 @@ export function systemHooks() {
  */
 
 async function itemDataFromActivity(activity, animationType) {
-	const item = activity?.parent?.parent;
+    const item = activity?.parent?.parent;
     const rinsedActivityName = activity?.name ? AAAutorecFunctions.rinseName(activity.name) : "noactivity";
     const autorecSettings = {
         melee: game.settings.get("autoanimations", "aaAutorec-melee"),
@@ -97,18 +97,18 @@ async function itemDataFromActivity(activity, animationType) {
     }
     const menus = AAAutorecFunctions.sortAndFilterMenus(autorecSettings);
     const found = AAAutorecFunctions.allMenuSearch(menus, rinsedActivityName, activity?.name);
-	const itemData = {
-		uuid: item?.uuid,
-		id: item?._id ?? item?.id,
-		_id: item?._id ?? item?.id,
-		parent: item?.parent,
-		actor: item?.parent,
-		name: found && validMenus?.[animationType].includes(found?.menu) && !["attack", "check", "damage", "enchant", "heal", "save", "summon", "utility"].includes(activity?.name?.trim()?.toLowerCase()) ? activity?.name : item?.name,
-		type: item?.type,
-		system: item?.system,
+    const itemData = {
+	uuid: item?.uuid,
+	id: item?._id ?? item?.id,
+	_id: item?._id ?? item?.id,
+	parent: item?.parent,
+	actor: item?.parent,
+	name: found && validMenus?.[animationType].includes(found?.menu) && !["attack", "check", "damage", "enchant", "heal", "save", "summon", "utility"].includes(activity?.name?.trim()?.toLowerCase()) ? activity?.name : item?.name,
+	type: item?.type,
+	system: item?.system,
         flags: item?.flags
-	}
-	return itemData;
+    }
+    return itemData;
 }
 
 async function useItem(input) {

--- a/src/system-support/aa-dnd5e.js
+++ b/src/system-support/aa-dnd5e.js
@@ -32,7 +32,7 @@ export function systemHooks() {
             if (["circle", "cone", "cube", "cylinder", "line", "sphere", "square", "wall"].includes(activity?.target?.template?.type) || (activity?.damage?.parts?.length && activity?.type != "heal" && playOnDamage)) { return; }
             const item = activity?.parent?.parent;
             const ammoItem = item?.parent?.items?.get(data?.ammoUpdate?.id) ?? null;
-            const overrideNames = activity?.name ? ["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [] : [activity.name] : [];
+            const overrideNames = activity?.name && !["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [activity.name] : [];
             criticalCheck(roll, item);
             attack(await getRequiredData({item: item, actor: item.parent, workflow: item, rollAttackHook: {item, roll}, spellLevel: roll?.data?.item?.level ?? void 0, ammoItem, overrideNames})); 
         });
@@ -42,7 +42,7 @@ export function systemHooks() {
             const playOnDamage = game.settings.get('autoanimations', 'playonDamageCore');
             if (["circle", "cone", "cube", "cylinder", "line", "sphere", "square", "wall"].includes(activity?.target?.template?.type) || (activity?.type == "attack" && !playOnDamage)) { return; }
             const item = activity?.parent?.parent;
-            const overrideNames = activity?.name ? ["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [] : [activity.name] : [];
+            const overrideNames = activity?.name && !["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [activity.name] : [];
             damage(await getRequiredData({item, actor: item.parent, workflow: item, rollDamageHook: {item, roll}, spellLevel: roll?.data?.item?.level ?? void 0, overrideNames}));
         });
         Hooks.on('dnd5e.postUseActivity', async (activity, usageConfig, results) => {
@@ -50,7 +50,7 @@ export function systemHooks() {
             const config = usageConfig;
             const options = results;
             const item = activity?.parent?.parent;
-            const overrideNames = activity?.name ? ["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [] : [activity.name] : [];
+            const overrideNames = activity?.name && !["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [activity.name] : [];
             useItem(await getRequiredData({item, actor: item.parent, workflow: item, useItemHook: {item, config, options}, spellLevel: options?.flags?.dnd5e?.use?.spellLevel || void 0, overrideNames}));
         });
     }
@@ -70,7 +70,7 @@ export function systemHooks() {
         if (userId !== game.user.id) { return };
         const activity = await fromUuid(template.flags?.dnd5e?.origin);
         const item = activity ? activity?.parent?.parent : template?.flags?.autoanimations?.itemData;
-        const overrideNames = activity?.name ? ["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [] : [activity.name] : [];
+        const overrideNames = activity?.name && !["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [activity.name] : [];
         templateAnimation(await getRequiredData({item, templateData: template, workflow: template, isTemplate: true, overrideNames}));
     });
     /*

--- a/src/system-support/aa-dnd5e.js
+++ b/src/system-support/aa-dnd5e.js
@@ -42,9 +42,8 @@ export function systemHooks() {
             const playOnDamage = game.settings.get('autoanimations', 'playonDamageCore');
             if (["circle", "cone", "cube", "cylinder", "line", "sphere", "square", "wall"].includes(activity?.target?.template?.type) || (activity?.type == "attack" && !playOnDamage)) { return; }
             const item = activity?.parent?.parent;
-            const ammoItem = item?.parent?.items?.get(data?.ammoUpdate?.id) ?? null;
             const overrideNames = activity?.name ? ["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [] : [activity.name] : [];
-            damage(await getRequiredData({item, actor: item.parent, workflow: item, rollDamageHook: {item, roll}, spellLevel: roll?.data?.item?.level ?? void 0, ammoItem, overrideNames}));
+            damage(await getRequiredData({item, actor: item.parent, workflow: item, rollDamageHook: {item, roll}, spellLevel: roll?.data?.item?.level ?? void 0, overrideNames}));
         });
         Hooks.on('dnd5e.postUseActivity', async (activity, usageConfig, results) => {
             if (["circle", "cone", "cube", "cylinder", "line", "sphere", "square", "wall"].includes(activity?.target?.template?.type) || activity?.type == "attack" || (activity?.damage?.parts?.length && activity?.type != "heal")) { return; }

--- a/src/system-support/aa-dnd5e.js
+++ b/src/system-support/aa-dnd5e.js
@@ -2,7 +2,6 @@ import { debug }            from "../constants/constants.js";
 import { trafficCop }       from "../router/traffic-cop.js";
 import AAHandler            from "../system-handlers/workflow-data.js";
 import { getRequiredData }  from "./getRequiredData.js";
-import { AAAutorecFunctions } from "../aa-classes/aaAutorecFunctions.js";
 
 // DnD5e System hooks provided to run animations
 export function systemHooks() {
@@ -31,43 +30,49 @@ export function systemHooks() {
             const activity = data.subject;
             const playOnDamage = game.settings.get('autoanimations', 'playonDamageCore');
             if (["circle", "cone", "cube", "cylinder", "line", "sphere", "square", "wall"].includes(activity?.target?.template?.type) || (activity?.damage?.parts?.length && activity?.type != "heal" && playOnDamage)) { return; }
-            const itemData = await itemDataFromActivity(activity, "attack");
-            const ammoItem = itemData?.parent?.items?.get(data?.ammoUpdate?.id) ?? null;
-            criticalCheck(roll, itemData);
-            attack(await getRequiredData({item: itemData, actor: itemData.parent, workflow: itemData, rollAttackHook: {itemData, roll}, spellLevel: roll?.data?.item?.level ?? void 0, ammoItem})); 
+            const item = activity?.parent?.parent;
+            const ammoItem = item?.parent?.items?.get(data?.ammoUpdate?.id) ?? null;
+            const overrideNames = activity?.name ? ["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [] : [activity.name] : [];
+            criticalCheck(roll, item);
+            attack(await getRequiredData({item: item, actor: item.parent, workflow: item, rollAttackHook: {item, roll}, spellLevel: roll?.data?.item?.level ?? void 0, ammoItem, overrideNames})); 
         });
         Hooks.on("dnd5e.rollDamageV2", async (rolls, data) => {
             const roll = rolls[0];
             const activity = data.subject;
             const playOnDamage = game.settings.get('autoanimations', 'playonDamageCore');
             if (["circle", "cone", "cube", "cylinder", "line", "sphere", "square", "wall"].includes(activity?.target?.template?.type) || (activity?.type == "attack" && !playOnDamage)) { return; }
-            const itemData = await itemDataFromActivity(activity, "damage");
-            const ammoItem = itemData?.parent?.items?.get(data?.ammoUpdate?.id) ?? null;
-            damage(await getRequiredData({item: itemData, actor: itemData.parent, workflow: itemData, rollDamageHook: {itemData, roll}, spellLevel: roll?.data?.item?.level ?? void 0, ammoItem}));
+            const item = activity?.parent?.parent;
+            const ammoItem = item?.parent?.items?.get(data?.ammoUpdate?.id) ?? null;
+            const overrideNames = activity?.name ? ["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [] : [activity.name] : [];
+            damage(await getRequiredData({item, actor: item.parent, workflow: item, rollDamageHook: {item, roll}, spellLevel: roll?.data?.item?.level ?? void 0, ammoItem, overrideNames}));
         });
         Hooks.on('dnd5e.postUseActivity', async (activity, usageConfig, results) => {
             if (["circle", "cone", "cube", "cylinder", "line", "sphere", "square", "wall"].includes(activity?.target?.template?.type) || activity?.type == "attack" || (activity?.damage?.parts?.length && activity?.type != "heal")) { return; }
             const config = usageConfig;
             const options = results;
-            const itemData = await itemDataFromActivity(activity, "utility");
-            useItem(await getRequiredData({item: itemData, actor: itemData.parent, workflow: itemData, useItemHook: {itemData, config, options}, spellLevel: options?.flags?.dnd5e?.use?.spellLevel || void 0}));
+            const item = activity?.parent?.parent;
+            const overrideNames = activity?.name ? ["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [] : [activity.name] : [];
+            useItem(await getRequiredData({item, actor: item.parent, workflow: item, useItemHook: {item, config, options}, spellLevel: options?.flags?.dnd5e?.use?.spellLevel || void 0, overrideNames}));
         });
     }
     Hooks.on("dnd5e.preCreateActivityTemplate", async (activity, templateData) => {
-        templateData.flags.autoanimations = {itemData: {
-            parent: activity?.parent?.parent?.parent,
-	    actor: activity?.parent?.parent?.parent,
-	    name: activity?.parent?.parent?.name,
-	    type: activity?.parent?.parent?.type,
-	    system: activity?.parent?.parent?.system,
-            flags: activity?.parent?.parent?.flags
-        }}
+        templateData.flags.autoanimations = {
+            itemData: {
+                parent: activity?.parent?.parent?.parent,
+                actor: activity?.parent?.parent?.parent,
+                name: activity?.parent?.parent?.name,
+                type: activity?.parent?.parent?.type,
+                system: activity?.parent?.parent?.system,
+                flags: activity?.parent?.parent?.flags
+            }
+        }
     });
     Hooks.on("createMeasuredTemplate", async (template, data, userId) => {
         if (userId !== game.user.id) { return };
         const activity = await fromUuid(template.flags?.dnd5e?.origin);
-        const itemData = activity ? await itemDataFromActivity(activity, "template") : template?.flags?.autoanimations?.itemData;
-        templateAnimation(await getRequiredData({item: itemData, templateData: template, workflow: template, isTemplate: true}));
+        const item = activity ? activity?.parent?.parent : template?.flags?.autoanimations?.itemData;
+        const overrideNames = activity?.name ? ["heal", "summon"].includes(activity?.name?.trim()?.toLowerCase()) ? [] : [activity.name] : [];
+        templateAnimation(await getRequiredData({item, templateData: template, workflow: template, isTemplate: true, overrideNames}));
     });
     /*
     Hooks.on("createMeasuredTemplate", async (template, data, userId) => {
@@ -88,40 +93,6 @@ export function systemHooks() {
  * @param {Boolean} hasDamage // Checks if the item has Damage
  *  
  */
-
-async function itemDataFromActivity(activity, animationType) {
-    const item = activity?.parent?.parent;
-    const rinsedActivityName = activity?.name ? AAAutorecFunctions.rinseName(activity.name) : "noactivity";
-    const autorecSettings = {
-        melee: game.settings.get("autoanimations", "aaAutorec-melee"),
-        range: game.settings.get("autoanimations", "aaAutorec-range"),
-        ontoken: game.settings.get("autoanimations", "aaAutorec-ontoken"),
-        templatefx: game.settings.get("autoanimations", "aaAutorec-templatefx"),
-        aura: game.settings.get("autoanimations", "aaAutorec-aura"),
-        preset: game.settings.get("autoanimations", "aaAutorec-preset"),
-        aefx: game.settings.get("autoanimations", "aaAutorec-aefx")
-    }
-    const validMenus = {
-        attack: ["melee", "ranged", "ontoken", "preset"],
-        damage: ["melee", "ranged", "ontoken", "preset", "aura"],
-        utility: ["ontoken", "preset", "aura"],
-        template: ["templatefx", "preset"]
-    }
-    const menus = AAAutorecFunctions.sortAndFilterMenus(autorecSettings);
-    const found = AAAutorecFunctions.allMenuSearch(menus, rinsedActivityName, activity?.name);
-    const itemData = {
-	uuid: item?.uuid,
-	id: item?._id ?? item?.id,
-	_id: item?._id ?? item?.id,
-	parent: item?.parent,
-	actor: item?.parent,
-	name: found && validMenus?.[animationType].includes(found?.menu) && !["attack", "check", "damage", "enchant", "heal", "save", "summon", "utility"].includes(activity?.name?.trim()?.toLowerCase()) ? activity?.name : item?.name,
-	type: item?.type,
-	system: item?.system,
-        flags: item?.flags
-    }
-    return itemData;
-}
 
 async function useItem(input) {
     debug("Item used, checking for animations")


### PR DESCRIPTION
Changed system hooks to non-deprecated versions:
- dnd5e.rollAttack -> dnd5e.rollAtttackV2
- dnd5e.rollDamage -> dnd5e.rollDamageV2
- dnd5e.useItem -> dnd5e.postUseActivity

Removed use of deprecated item properties hasAreaTarget, hasAttack, and hasDamage.

Added system hook to add item data as flag on templates to cover cases where the origin item is unavailable due to being consumed.

Moved ammo check into the attack system hook.

Added activity name as an override name taking precedence over item name for auto-recognition.